### PR TITLE
Add features: render_all_frames executable, calculate occlusion + truncation values

### DIFF
--- a/c++/README.md
+++ b/c++/README.md
@@ -66,6 +66,13 @@ Our renderer application additionally requires OpenGL, GLFW3, GLEW, [Assimp](htt
   ./rio_renderer ../../../data/3RScan 754e884c-ea24-2175-8b34-cead19d4198d ./
 ```
 
+Our renderer application offers an additional binary that renders all artifacts (bounding-box file; rendered rgb, label, instance and depth image; occlusion scores for each object) for each frame in a scan:
+
+```bash
+  ./rio_renderer_render_all <3RScan_path> <scan_id> <output_path> <render_only_occlusions> <fov_scale>
+  ./rio_renderer_render_all ../../../data/3RScan 754e884c-ea24-2175-8b34-cead19d4198d ./ 1 2.0
+```
+
 ## Citation
 
 If you find this useful, please consider citing the corresponding publication:

--- a/c++/rio_renderer/CMakeLists.txt
+++ b/c++/rio_renderer/CMakeLists.txt
@@ -13,7 +13,18 @@ find_package(assimp REQUIRED)
 add_executable(${PROJECT_NAME} src/main.cc src/data.cc 
 								src/util.cc src/renderer.cc src/json11.cpp)
 
+add_executable(${PROJECT_NAME}_render_all src/render_all_main.cc src/data.cc 
+								src/util.cc src/renderer.cc src/json11.cpp)
+
 target_include_directories(${PROJECT_NAME} PRIVATE include
+					${EIGEN3_INCLUDE_DIR}
+					${OPENGL_INCLUDE_DIR}
+					${OpenCV_INCLUDE_DIRS}
+					${GLFW_INCLUDE_DIRS}
+					${GLEW_INCLUDE_PATH}
+					${assimp_INCLUDE_DIRS})
+
+target_include_directories(${PROJECT_NAME}_render_all PRIVATE include
 					${EIGEN3_INCLUDE_DIR}
 					${OPENGL_INCLUDE_DIR}
 					${OpenCV_INCLUDE_DIRS}
@@ -23,4 +34,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE include
 
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED YES)
 target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBS} ${OPENGL_LIBRARIES}
+									${GLFW_LIBRARIES} ${GLEW_LIBRARY} ${assimp_LIBRARIES})
+
+target_link_libraries(${PROJECT_NAME}_render_all ${OpenCV_LIBS} ${OPENGL_LIBRARIES}
 									${GLFW_LIBRARIES} ${GLEW_LIBRARY} ${assimp_LIBRARIES})

--- a/c++/rio_renderer/include/data.h
+++ b/c++/rio_renderer/include/data.h
@@ -19,17 +19,20 @@ namespace RIO {
 
 class Data {
 public:
-    Data(const std::string& path);
+    Data(const std::string& path, float fov_scale = 1.0f);
     Intrinsics intrinsics;
 
     void LoadViewMatrix();
     bool LoadIntrinsics();
     void NextFrame();
     void SetFrame(const int frame_id);
+    bool HasNextFrame() const;
 
     const Eigen::Matrix4f& pose() const;
     const int frame_id() const;
+    const float fov_scale() const;
 private:
+    const float fov_scale_;
     const std::string data_path_{""};
     int frame_id_{0};
     struct DataConfig {

--- a/c++/rio_renderer/include/renderer.h
+++ b/c++/rio_renderer/include/renderer.h
@@ -29,22 +29,44 @@ class Renderer {
 public:
     Renderer(const std::string& sequence_path, 
              const std::string& data_path, 
-             const std::string& scan_id);
+             const std::string& scan_id,
+             bool save_images_and_bbox = true,
+             bool save_occlusion = false,
+             float fov_scale = 1.0f);
     ~Renderer();
     int Init();
     void Render(const bool inc_frame_id, const std::string save_path = "");
     void Render(const int frame_id, const std::string save_path = "");
+    void RenderAllFrames(const std::string save_path = "");
     const cv::Mat& GetLabels() const;
     const cv::Mat& GetColor() const;
     const cv::Mat& GetDepth() const;
     const std::map<int, Eigen::Vector4i>& Get2DBoundingBoxes() const;
     const std::map<int, std::string>& GetInstance2Label() const;
     const std::map<int, unsigned long>& GetInstance2Color() const;
+
+    struct VisibilityEntry {
+        VisibilityEntry():             
+            original_pixel_count(0),
+            complete_pixel_count(0),
+            ratio(1) { }
+
+        VisibilityEntry(const float original_pixel_count, const float complete_pixel_count):
+            original_pixel_count(original_pixel_count),
+            complete_pixel_count(complete_pixel_count),
+            ratio(original_pixel_count / complete_pixel_count) { }
+
+        float original_pixel_count;
+        float complete_pixel_count;
+        float ratio; // original / complete
+    };
 private:
     std::string data_path_{""};
     std::string sequence_path_{""};
     int buffer_width{0};
     int buffer_height{0};
+    bool save_images_and_bbox_{true};
+    bool save_occlusion_{false};
     bool initalized_{false};
     struct RIOData {
         RIOData(const std::string& scan_id): scan_id(scan_id) { }
@@ -54,13 +76,23 @@ private:
         std::map<unsigned long, int> color2instances;
         std::map<int, Eigen::Vector4i> bboxes;
 
+        // how much of an instance is cut off at the image edges (how much larger is one instance / what is not shown in this frame)
+        std::map<int, VisibilityEntry> instances2truncation;
+
+        // how much of the instance is cut off by other objects in the image (the portion that is visible in the frame: how much is occluded by other objects)
+        std::map<int, VisibilityEntry> instances2occlusion;
+
         cv::Mat instances;
         cv::Mat labels;
         cv::Mat color;
         cv::Mat depth;
+
+        cv::Mat labels_fov_scale;
+        cv::Mat label_one_instance_only;
     };
     RIOData rio_data_;
     Data data_;
+    Data data_fov_scale_;
     Eigen::Matrix4f projection_{Eigen::Matrix4f::Identity()};
 
     GLFWwindow *window{nullptr};
@@ -68,12 +100,16 @@ private:
     Shader* shader_RGB_{nullptr};
     Model* model_RGB_{nullptr};
     Model* model_labels_{nullptr};
+    std::map<int, Model*> instance2model_with_instance_only_;
 
     void InitGLFW();
     void Render(Model& model, Shader& shader);
     void ReadLabels(cv::Mat& image, cv::Mat& labels);
     void ReadRGB(cv::Mat& image);
     void ReadDepth(cv::Mat& image);
+    void CalcTruncations(std::map<int, unsigned long>& instances2color, std::map<int, VisibilityEntry>& instances2truncation, const cv::Mat& labels_fov_scale);
+    void CalcOcclusions(std::map<int, unsigned long>& instances2color, std::map<int, VisibilityEntry>& instances2occlusion, const cv::Mat& labels);
+    void VerifyTruncationAndOcclusion(std::map<int, VisibilityEntry>& instances2occlusion, std::map<int, VisibilityEntry>& instances2truncation);
     void DrawScene(Model& model, Shader& shader);
     bool LoadObjects(const std::string& obj_file);
 };

--- a/c++/rio_renderer/src/data.cc
+++ b/c++/rio_renderer/src/data.cc
@@ -26,7 +26,7 @@ void Data::SetFrame(const int frame) {
         frame_id_ = frame;
 }
 
-Data::Data(const std::string& path): data_path_(path) {
+Data::Data(const std::string& path, float fov_scale): data_path_(path), fov_scale_(fov_scale) {
 }
 
 void Data::LoadPose(const std::string& pose_file, Eigen::Matrix4f& pose) {
@@ -78,6 +78,14 @@ const int Data::frame_id() const {
     return frame_id_;
 }
 
+const float Data::fov_scale() const {
+    return fov_scale_;
+}
+
+bool Data::HasNextFrame() const {
+    return frame_id_ < poses_.size();
+}
+
 bool Data::LoadIntrinsics() {
     std::cout << data_path_ << "/" << data_config_.calib_file_ << std::endl;
     std::string line{""};
@@ -93,8 +101,8 @@ bool Data::LoadIntrinsics() {
             else if (line.rfind("m_calibrationColorIntrinsic", 0) == 0) {
                 const std::string model = line.substr(line.find("= ")+2, std::string::npos);
                 const auto parts = funct_utils::split(model, " ");
-                intrinsics.fx = std::stof(parts[0]);
-                intrinsics.fy = std::stof(parts[5]);
+                intrinsics.fx = std::stof(parts[0]) / fov_scale_;
+                intrinsics.fy = std::stof(parts[5]) / fov_scale_;
                 intrinsics.cx = std::stof(parts[2]);
                 intrinsics.cy = std::stof(parts[6]);
             }

--- a/c++/rio_renderer/src/render_all_main.cc
+++ b/c++/rio_renderer/src/render_all_main.cc
@@ -1,0 +1,38 @@
+/*******************************************************
+* Copyright (c) 2020, Johanna Wald
+* All rights reserved.
+*
+* This file is distributed under the GNU Lesser General Public License v3.0.
+* The complete license agreement can be obtained at:
+* http://www.gnu.org/licenses/lgpl-3.0.html
+********************************************************/
+
+#include <string>
+#include "renderer.h"
+#include <opencv2/core/core.hpp>
+#include "util.h"
+
+#include <cstdlib>
+
+int main (int argc, char* argv[]) {
+    if (argc < 4)
+        return 0;
+    const std::string data_path{argv[1]}; 
+    const std::string scan_id{argv[2]}; 
+    const std::string output_path{argv[3]}; 
+    const std::string seq_path = data_path + "/" + scan_id + "/sequence/";
+
+    bool render_only_occlusion = false;
+    float occlusion_fov_scale = 2.0f;
+    if (argc == 6){
+        render_only_occlusion = atoi(argv[4]);
+        occlusion_fov_scale = atof(argv[5]);
+
+        std::cout << "RENDER ONLY OCCLUSION: " << render_only_occlusion << std::endl;
+        std::cout << "OCCLUSION FOV SCALE: " << occlusion_fov_scale << std::endl;
+    }
+
+    RIO::Renderer renderer(seq_path, data_path, scan_id, !render_only_occlusion, true, occlusion_fov_scale);
+    renderer.Init();
+    renderer.RenderAllFrames(output_path);
+}


### PR DESCRIPTION
**render all frames sequentially in one call with the "render_all_main.cc" class and its "rio_renderer_render_all" binary**
- added a new function in the Renderer class: "RenderAllFrames". It calls the "Render" method sequentially for each frame.

**calculate and render visibility values (occlusion + truncation)**

We add the file `frame-xxxxxx.visibility.txt` that is used to store the calculated truncation and occlusion metrics. Its content are rows with following syntax:
`<instance_id> <truncation_number_pixels_original_image> <truncation_number_pixels_larger_fov_image> <truncation_metric> <occlusion_number_pixels_original_image> <occlusion_number_pixels_only_with_that_instance> <occlusion_metric>` 
where

- `instance_id`: as defined in `objects.json`

- `truncation_number_pixels_original_image`: how many pixels from instance are visible in the original part of the image when rendered with a larger fov, but only looking at the original crop.

- `truncation_number_pixels_larger_fov_image`: how many pixels from instance are visible in the larger fov image.

- `truncation`: percentage of how much the object is cut off at the edges w.r.t. rendering with larger FOV. 1 means "the whole object is visible in the original image, it is not cut off at image edges". 0<x<1 means "the object is visible to x% in the original image, the rest is cut off at image edges but is visible with a larger FOV".

- `occlusion_number_pixels_original_image`: how many pixels from instance are visible in original image with original fov.

- `occlusion_number_pixels_only_with_that_instance`: how many pixels from instance are visible in original image with original fov when only rendering that instance.

- `occlusion`: percentage of how much the object is cut off by other objects in the original image (without larger FOV). 1 means "the whole object is visible in the original image, it is not cut off by other objects in the image". 0<x<1 means "the object is visible to x% in the original image, the rest is cut off by other objects in the image, but is visible in the original FOV when only rendering that single object"

**Caveat:** Note that `truncation_number_pixels_original_image` and `occlusion_number_pixels_original_image` are not the same number. This is because we used a larger FOV for rendering the image in truncation and therefore the absolute number of pixels is less because we look at a smaller width/height in total. When using the number of pixels as object mask, we should therefore use the `occlusion_number_pixels_original_image`.

One example `frame-xxxxxx.visibility.txt` file can look like this:

```
1 39326 76215 0.515988 158780 268173 0.59208
2 10764 108274 0.0994144 41363 67629 0.611616
17 2663 6377 0.417594 10974 18437 0.595216
18 3190 3190 1 12769 12770 0.999922
19 36676 37854 0.96888 146999 146999 1
22 12373 187178 0.0661029 56761 56761 1
24 4345 20030 0.216925 14900 14900 1
25 13322 13325 0.999775 53334 56449 0.944817
28 2171 8714 0.249139 7958 8392 0.948284
33 2149 8319 0.258324 8267 8297 0.996384
```

This can be run with the new binary `rio_renderer_render_all` by calling it the usual way:

`./rio_renderer_render_all <data_path> <scan_id> <render_output> <render_only_occlusions> <fov_scale>`

e.g.

`./rio_renderer_render_all /home/lukas/datasets/3RScan/ 5630cfc9-12bf-2860-84ed-5bb189f0e94e /home/lukas/datasets/3RScan/tmp 1 2.0`

where:

- `render_only_occlusions`: if only the new `frame-xxxxxx.visibility.txt` files should be created (int value). If 0: also the other images will be rendered with the normal fov setting and saved. If 1: only the new file will be saved to disk. (default: 0)
- `fov_scale`: enlargement factor, e.g. 2.0 means that the enlarged image will have a twice as large FOV (default: 2.0)

You need to specify both arguments `<render_only_occlusions> <fov_scale>` for the current implementation to use any of them.